### PR TITLE
feature(main): Basic mixin implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,96 @@
 # loopback-typeorm
 A component to provide TypeORM in Loopback 4
 
+## Usage
+Note: These instructions aren't entirely applicable yet, this module has not
+been published.
+
+1. Install this plugin
+```ts
+npm install --save loopback-typeorm
+```
+2. In your application, make your own Application class, but instead of
+extending `Application`, you'll want to call the provided mixin as your base
+class.
+```ts
+import {Application} from '@loopback/core';
+import {TypeORMRepositoryMixin} from 'loopback-typeorm';
+
+export class MyApplication extends TypeORMRepositoryMixin(Application) {
+  constructor() {
+    super(...);
+  }
+}
+```
+3. Create a connection (or multiple!) in your new subclass, and define
+whatever repositories you'd like to create. 
+
+A helpful way to ensure that your configuration has all of the _required_ values
+is to import the `ConnectionOptions` type from TypeORM directly.
+
+**Note**: There are connection options that become required within different
+use cases and contexts. For info on how to configure your database connection,
+see the [TypeORM docs](https://github.com/typeorm/typeorm).
+
+```ts
+import {Application} from '@loopback/core';
+import {TypeORMRepositoryMixin} from 'loopback-typeorm';
+import {ConnectionOptions} from 'typeorm';
+import {Order, Customer} from './models';
+
+export class MyApplication extends TypeORMRepositoryMixin(Application) {
+  mySqlConnection: Connection;
+  constructor() {
+    super();
+    const connectionOptions: ConnectionOptions = {
+      name: 'connectionName',
+      host: 'somehost.com',
+      database: 'mydb',
+      port: 3306,
+      type: 'mysql',
+      username: 'admin',
+      password: 'secretpassword',
+      // etc...
+    };
+    this.mySqlConnection = this.createTypeOrmConnection(connectionOptions);
+
+    // Automatically uses the connection to bind repositories to
+    // your application context.
+    this.typeOrmRepository(this.mySqlConnection, Order);
+    this.typeOrmRepository(this.mySqlConnection, Customer);
+   }
+}
+```
+4. Finally, consume your repositories in your controllers!
+```ts
+import {Customer, CustomerSchema} from '../models';
+import {Repository} from 'typeorm';
+
+export class CustomerController {
+  constructor(@inject('repositories.Customer') customerRepo: Repository) {
+    // ...
+  }
+
+  @get('/customer/{id}')
+  @param.path.number('id');
+  async getCustomerById(id: number) {
+    // Using TypeORM's repository!
+    return await this.customerRepo.findOneById(id);
+  }
+
+  @post('/customer')
+  @param.body('customer', CustomerSchema);
+  async createCustomer(customer: Customer) {
+    return await this.customerRepo.save(customer);
+  }
+}
+```
+
+## Testing
+To run tests, you'll need an installation of Docker.
+```
+npm it
+```
+
 [![LoopBack](http://loopback.io/images/overview/powered-by-LB-xs.png)](http://loopback.io/)
 

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,1 @@
-// Copyright IBM Corp. 2017. All Rights Reserved.
-// Node module: loopback-typeorm
-// This file is licensed under the MIT License.
-// License text available at https://opensource.org/licenses/MIT
-
-// NOTE(bajtos) This file is used by TypeScript compiler to resolve imports
-// from "test" files against original TypeScript sources in "src" directory.
-// As a side effect, `tsc` also produces "dist/index.{js,d.ts,map} files
-// that allow test files to import paths pointing to {src,test} root directory,
-// which is project root for TS sources but "dist" for transpiled sources.
 export * from './src';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "loopback-typeorm",
   "version": "0.0.1",
   "description": "A component to provide TypeORM in Loopback 4",
-  "keywords": ["loopback-application", "loopback"],
+  "keywords": [
+    "loopback-application",
+    "loopback"
+  ],
   "main": "index.js",
   "engines": {
     "node": ">=8"
@@ -16,28 +19,42 @@
     "prettier:cli": "prettier \"**/*.ts\" \"**/*.js\"",
     "prettier:check": "npm run prettier:cli -- -l",
     "prettier:fix": "npm run prettier:cli -- --write",
-    "tslint": "tslint",
+    "tslint": "tslint .",
     "tslint:fix": "npm run tslint -- --fix",
     "pretest": "npm run clean && npm run build",
     "posttest": "npm run lint",
     "start": "npm run build && node .",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test": "npm run build && node ./dist/test/setup.js"
   },
   "repository": {
     "type": "git"
   },
   "author": "",
   "license": "MIT",
-  "files": ["README.md", "index.js", "index.d.ts", "dist"],
+  "files": [
+    "README.md",
+    "index.js",
+    "index.d.ts",
+    "dist"
+  ],
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.18",
     "@loopback/core": "^4.0.0-alpha.20",
-    "@loopback/rest": "^4.0.0-alpha.7"
+    "typeorm": "^0.1.2"
   },
   "devDependencies": {
+    "@loopback/build": "^4.0.0-alpha.5",
+    "@loopback/testlab": "^4.0.0-alpha.14",
+    "@types/debug": "0.0.30",
+    "@types/dockerode": "^2.5.1",
+    "@types/mocha": "^2.2.44",
+    "debug": "^3.1.0",
+    "dockerode": "^2.5.3",
+    "mocha": "^4.0.1",
+    "mysql": "^2.15.0",
     "prettier": "^1.7.3",
     "tslint": "^5.7.0",
-    "@loopback/testlab": "^4.0.0-alpha.13",
     "typescript": "^2.5.3"
   }
 }

--- a/src/connection-manager.ts
+++ b/src/connection-manager.ts
@@ -1,0 +1,7 @@
+import {ConnectionManager, Connection} from 'typeorm';
+
+export class TypeORMConnectionManager extends ConnectionManager {
+  // This is to allow more direct access to the connection objects
+  // during start/stop of the application.
+  public connections: Connection[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './typeorm-mixin';

--- a/src/typeorm-mixin.ts
+++ b/src/typeorm-mixin.ts
@@ -1,0 +1,103 @@
+import {Application, Component, Server} from '@loopback/core';
+import {Context, Binding, Constructor} from '@loopback/context';
+import {Connection, Entity, BaseEntity, ConnectionOptions} from 'typeorm';
+import {TypeORMConnectionManager} from './connection-manager';
+
+// tslint:disable:no-any
+export function TypeORMMixin(
+  superClass: typeof Application,
+): TypeORMApplicationClass {
+  return class extends superClass {
+    typeOrmConnectionManager: TypeORMConnectionManager;
+    constructor(...args: any[]) {
+      super(...args);
+      this.typeOrmConnectionManager = new TypeORMConnectionManager();
+      this.bind('typeorm.connections.manager').to(
+        this.typeOrmConnectionManager,
+      );
+    }
+
+    async start() {
+      for (const connection of this.typeOrmConnectionManager.connections) {
+        await connection.connect();
+      }
+      await super.start();
+    }
+
+    async stop() {
+      for (const connection of this.typeOrmConnectionManager.connections) {
+        await connection.close();
+      }
+      await super.stop();
+    }
+
+    /**
+     * Register a TypeORM-based repository instance of the given class.
+     * Generated repositories will be bound using the `repositories.{name}`
+     * convention.
+     *
+     * ```ts
+     * this.typeOrmRepository(Foo);
+     * const fooRepo = this.getSync(`repositories.Foo`);
+     * ```
+     *
+     * @param ctor The constructor (class) that represents the entity to
+     * generate a repository for.
+     */
+    typeOrmRepository<S>(
+      connection: Connection,
+      ctor: Constructor<S>,
+    ): Binding {
+      // XXX(kjdelisle): I wanted to make this a provider, but it requires
+      // the constructor instance to be available in the provider scope, which
+      // would require injection of each constructor, so I had to settle for
+      // this instead.
+      return this.bind(`repositories.${ctor.name}`).toDynamicValue(async () => {
+        if (!connection.isConnected) {
+          await connection.connect();
+        }
+        return connection.getRepository(ctor);
+      });
+    }
+
+    /**
+     * Get an existing connection instance from the connection manager,
+     * or create one if it does not exist. If you do not provide a name, a
+     * default connection instance will be provided.
+     * @param name The name of the connection (if it already exists)
+     */
+    getTypeOrmConnection(name?: string): Connection {
+      return this.typeOrmConnectionManager.get(name);
+    }
+
+    /**
+     * Create a new TypeORM connection with the provided set of options.
+     * @param options
+     */
+    createTypeOrmConnection(options: ConnectionOptions): Connection {
+      if (!options) {
+        throw new Error('Connection options are required!');
+      }
+      return this.typeOrmConnectionManager.create(options);
+    }
+  };
+}
+
+/**
+ * Define any implementation of Application.
+ */
+
+export interface TypeORMApplication extends Application {
+  typeOrmRepository<S>(connection: Connection, ctor: Constructor<S>): Binding;
+  createTypeOrmConnection(options: ConnectionOptions): Connection;
+  getTypeOrmConnection(name?: string): Connection;
+}
+
+export interface TypeORMApplicationClass
+  extends Constructor<TypeORMApplication> {
+  [property: string]: any;
+}
+
+export interface Options {
+  [property: string]: any;
+}

--- a/test/acceptance.test.ts
+++ b/test/acceptance.test.ts
@@ -1,0 +1,144 @@
+import 'mocha';
+import {expect} from '@loopback/testlab';
+import {Application} from '@loopback/core';
+import {TypeORMMixin} from '../src/index';
+import {
+  Repository,
+  ConnectionOptions,
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Connection,
+  OneToMany,
+  ManyToOne,
+  JoinTable,
+} from 'typeorm';
+import * as util from 'util';
+
+/* 
+ * ============================================================================
+ * FIXTURES
+ * ============================================================================
+ */
+class TestApplication extends TypeORMMixin(Application) {
+  connectionOne: Connection;
+  connectionTwo: Connection;
+  constructor() {
+    super();
+    const fakeConnectionInfo: ConnectionOptions = {
+      host: process.env.MYSQL_HOST || 'localhost',
+      database: process.env.MYSQL_DATABASE || 'testdb',
+      port: Number.parseInt(process.env.MYSQL_PORT || '3306'),
+      type: 'mysql',
+      username: process.env.MYSQL_USERNAME || 'root',
+      password: process.env.MYSQL_PASSWORD || 'pass',
+      entities: [Customer, Order],
+      synchronize: true,
+    };
+    console.log(
+      `Connection Info: ${util.inspect(fakeConnectionInfo, undefined, 2)}`,
+    );
+    this.connectionOne = this.createTypeOrmConnection(
+      Object.assign({name: 'one'}, fakeConnectionInfo),
+    );
+    this.connectionTwo = this.createTypeOrmConnection(
+      Object.assign({name: 'two'}, fakeConnectionInfo),
+    );
+
+    this.typeOrmRepository(this.connectionOne, Order);
+    this.typeOrmRepository(this.connectionTwo, Customer);
+  }
+}
+
+@Entity()
+class Order {
+  @PrimaryGeneratedColumn() id: number;
+  @Column() orderDate: Date;
+  @ManyToOne(type => Customer, customer => customer.orders)
+  customer: number;
+  @Column({type: 'int', nullable: true})
+  customerId: number;
+}
+
+@Entity()
+class Customer {
+  @PrimaryGeneratedColumn() id: number;
+  @Column() name?: string;
+  @Column() address?: string;
+  @OneToMany(type => Order, order => order.customer)
+  @JoinTable()
+  orders: Order[];
+}
+
+/*
+ * ============================================================================
+ * TESTS 
+ * ============================================================================
+ */
+
+describe('TypeORM Repository Mixin', () => {
+  const app = new TestApplication();
+  before(async () => {
+    await app.start();
+  });
+
+  it('creates repository bindings', async () => {
+    expect(await app.get(`repositories.Order`)).to.be.instanceof(Repository);
+    expect(await app.get(`repositories.Customer`)).to.be.instanceof(Repository);
+  });
+
+  describe('operations', () => {
+    // NOTE: This is not meant to be a fully functional set of CRUD tests.
+    // TypeORM has its own suite of tests.
+    it('can create entities', async () => {
+      const customer = getCustomer();
+      const repo = (await app.get(
+        `repositories.${Customer.name}`,
+      )) as Repository<Customer>;
+      const foo = await repo.save(customer);
+      const result = await repo.findOneById(foo.id);
+      expect(result).to.deepEqual(foo);
+    });
+
+    it('can run more advanced queries', async () => {
+      let customer = getCustomer();
+      const customerRepo = (await app.get(
+        'repositories.Customer',
+      )) as Repository<Customer>;
+      customer = await customerRepo.save(customer);
+      let order = getOrder(customer.id);
+      const orderRepo = (await app.get('repositories.Order')) as Repository<
+        Order
+      >;
+      order = await orderRepo.save(order);
+
+      let result = (await customerRepo
+        .createQueryBuilder('customer')
+        .innerJoinAndSelect('customer.orders', 'orders')
+        .getOne()) as Customer;
+
+      expect(result).to.containDeep(customer);
+      expect(result.orders[0]).to.containDeep(order);
+    });
+  });
+
+  after(async () => {
+    await app.stop();
+  });
+});
+
+function getCustomer(customer?: Partial<Customer>): Customer {
+  const base = new Customer();
+  base.id = 0;
+  base.name = 'someName';
+  base.address = '123 Fake St.';
+  return Object.assign(base, customer);
+}
+
+function getOrder(customerId: number, order?: Partial<Order>): Order {
+  const base = new Order();
+  base.id = 0;
+  base.orderDate = new Date('2012-12-25T00:00:00.000Z');
+  base.customerId = customerId;
+  return Object.assign(base, order);
+}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,284 @@
+'use strict';
+import * as Dockerode from 'dockerode';
+import {Stream} from 'stream';
+import * as debug from 'debug';
+
+const debugMsg = debug('setup');
+import {get, includes, isEmpty, pick} from 'lodash';
+const async = require('async');
+const spawn = require('child_process').spawn;
+const docker = new Dockerode();
+const fmt = require('util').format;
+const http = require('http');
+const ms = require('ms');
+
+// we don't pass any node flags, so we can call _mocha instead the wrapper
+const mochaBin = require.resolve('mocha/bin/_mocha');
+
+process.env.MYSQL_DATABASE = 'testdb';
+process.env.MYSQL_PASSWORD = 'pass';
+process.env.MYSQL_USERNAME = 'root';
+
+// these are placeholders. They get set dynamically based on what IP and port
+// get assigned by docker.
+process.env.MYSQL_PORT = '3306';
+process.env.MYSQL_HOST = 'TBD';
+process.env.MYSQL_URL = 'TBD';
+
+const CONNECT_RETRIES = 30;
+const CONNECT_DELAY = ms('5s');
+
+let containerToDelete: Dockerode.Container;
+// tslint:disable:no-any
+// tslint:disable:no-shadowed-variable
+async.waterfall(
+  [
+    dockerStart('mysql:latest'),
+    sleep(ms('5s')),
+    setEnv,
+    waitFor(),
+    sleep(ms('5s')),
+    createDB('testdb'),
+    run([
+      mochaBin,
+      '--timeout',
+      '40000',
+      '--recursive',
+      './dist/test/**.test.js',
+    ]),
+  ],
+  function(testErr: Error) {
+    dockerCleanup(function(cleanupErr: Error) {
+      if (cleanupErr) {
+        console.error('error cleaning up:', cleanupErr);
+      }
+      if (testErr) {
+        console.error('error running tests:', testErr);
+        process.exit(1);
+      }
+    });
+  },
+);
+
+function sleep(n: number) {
+  return function delayedPassThrough() {
+    const args = [].slice.call(arguments);
+    // last argument is the callback
+    const next = args.pop();
+    // prepend `null` to indicate no error
+    args.unshift(null);
+    setTimeout(function() {
+      next.apply(null, args);
+    }, n);
+  };
+}
+
+function dockerStart(imgName: string) {
+  return function pullAndStart(next: Function) {
+    console.log('pulling image: %s', imgName);
+    docker.pull(imgName, function(err: Error, stream: Stream) {
+      docker.modem.followProgress(stream, function(err: Error, output: any) {
+        if (err) {
+          return next(err);
+        }
+        console.log('starting container from image: %s', imgName);
+        docker.createContainer(
+          {
+            Image: imgName,
+            HostConfig: {
+              PublishAllPorts: true,
+            },
+            Env: [
+              `MYSQL_ROOT_USER=${process.env.MYSQL_USERNAME}`,
+              `MYSQL_ROOT_PASSWORD=${process.env.MYSQL_PASSWORD}`,
+            ],
+          },
+          function(err, container: Dockerode.Container) {
+            console.log(
+              'recording container for later cleanup: ',
+              container.id,
+            );
+            containerToDelete = container;
+            if (err) {
+              return next(err);
+            }
+            container.start((err: Error, data: any) => {
+              next(err, container);
+            });
+          },
+        );
+      });
+    });
+  };
+}
+
+function setEnv(container: Dockerode.Container, next: Function) {
+  container.inspect(function(err, c) {
+    // if swarm, Node.Ip will be set to actual node's IP
+    // if not swarm, but remote docker, use docker host's IP
+    // if local docker, use localhost
+    const host = get(c, 'Node.IP', get(docker, 'modem.host', '127.0.0.1'));
+    // container's port 3306 is dynamically mapped to an external port
+    const port = get(c, [
+      'NetworkSettings',
+      'Ports',
+      '3306/tcp',
+      '0',
+      'HostPort',
+    ]) as string;
+    process.env.MYSQL_PORT = port;
+    process.env.MYSQL_HOST = host;
+    const usr = process.env.MYSQL_USERNAME;
+    const pass = process.env.MYSQL_PASSWORD;
+    console.log(
+      'env:',
+      pick(process.env, [
+        'MYSQL_HOST',
+        'MYSQL_PORT',
+        'MYSQL_USERNAME',
+        'MYSQL_PASSWORD',
+        'MYSQL_DATABASE',
+      ]),
+    );
+    next(null, container);
+  });
+}
+
+function waitFor() {
+  return function waitForPing(container: Dockerode.Container, next: Function) {
+    console.log('waiting for instance to respond');
+    return ping(null, CONNECT_RETRIES);
+
+    function ping(err: Error | null, tries: number) {
+      console.log('ping (%d/%d)', CONNECT_RETRIES - tries, CONNECT_RETRIES);
+      if (tries < 1) {
+        next(err || new Error('failed to contact mysql'));
+      }
+      const expected = '1\n1';
+      runDBCommand(container, 'SELECT 1', expected, function(err?: Error) {
+        if (err) {
+          debugMsg(`failed ping: ${err.message}`);
+          tryAgain(err);
+        } else {
+          setImmediate(next, null, container);
+        }
+      });
+      function tryAgain(err?: Error) {
+        console.log('retrying...');
+        setTimeout(ping, CONNECT_DELAY, err, tries - 1);
+      }
+    }
+  };
+}
+
+function runDBCommand(
+  container: Dockerode.Container,
+  cmd: string,
+  expectedOutput: string | null,
+  next: (...args: any[]) => void,
+) {
+  container.exec(
+    {
+      Cmd: [
+        '/bin/bash',
+        '-c',
+        `mysql -hlocalhost -p${process.env.MYSQL_PASSWORD} -P${
+          process.env.MYSQL_PORT
+        } --execute "${cmd};"`,
+        // `mysql -h${process.env.MYSQL_HOST} -p${process.env
+        // .MYSQL_PASSWORD} -P${process.env.MYSQL_PORT} --execute "${cmd};"`,
+      ],
+      AttachStdOut: true,
+      AttachStdErr: true,
+    },
+    (err: Error, exec: Dockerode.Exec) => {
+      if (err) {
+        console.log(`DB command failed: ${err}`);
+        next(err);
+      } else {
+        exec.start((error: Error, stream: NodeJS.ReadStream) => {
+          if (error) {
+            return next(error);
+          }
+          debugMsg('Data:');
+          stream.setEncoding('utf-8');
+          stream.once('data', (data: any) => {
+            if (isEmpty(data)) {
+              return next(new Error('(no data)'));
+            }
+            if (includes(data, 'ERROR')) {
+              debugMsg(data);
+              return next(new Error());
+            } else {
+              if (expectedOutput && !includes(data, expectedOutput)) {
+                debugMsg(`expected: ${expectedOutput}, received: ${data}`);
+                return next(new Error());
+              }
+              return next();
+            }
+          });
+        });
+      }
+    },
+  );
+}
+
+function createDB(db: string) {
+  return function create(
+    container: Dockerode.Container,
+    next: (...args: any[]) => void,
+  ) {
+    console.log(`creating db: ${db}`);
+    runDBCommand(
+      container,
+      `CREATE DATABASE IF NOT EXISTS ${db}`,
+      null,
+      (err?: Error) => {
+        if (err) {
+          debugMsg(`error creating db: ${err}`);
+        }
+        next(err, container);
+      },
+    );
+  };
+}
+
+function run(cmd: string[]) {
+  return function spawnNode(container: Dockerode.Container, next: Function) {
+    console.log('running mocha...');
+    spawn(process.execPath, cmd, {stdio: 'inherit'})
+      .on('error', next)
+      .on('exit', onExit);
+
+    function onExit(code: number, sig: string) {
+      if (code) {
+        next(new Error(fmt('mocha exited with code: %j, sig: %j', code, sig)));
+      } else {
+        next();
+      }
+    }
+  };
+}
+
+// clean up any previous containers
+function dockerCleanup(next: Function) {
+  // if (containerToDelete) {
+  //   console.log('cleaning up container: %s', containerToDelete.id);
+  //   containerToDelete.remove({force: true}, function(err) {
+  //     next(err);
+  //   });
+  // } else {
+  //   setImmediate(next);
+  // }
+  setImmediate(next);
+}
+
+// A Writable Stream that just consumes a stream. Useful for draining readable
+// streams so that they 'end' properly, like sometimes-empty http responses.
+function devNull() {
+  return new Stream.Writable({
+    write: function(_chunk, _encoding, cb) {
+      return cb(null);
+    },
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-    "compilerOptions": {
+  "compilerOptions": {
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
@@ -13,13 +13,6 @@
     "sourceMap": true,
     "declaration": true
   },
-    "include": [
-    "src",
-    "test"
-  ],
-  "exclude": [
-    "node_modules/**",
-    "packages/*/node_modules/**",
-    "**/*.d.ts"
-  ]
+  "include": ["src", "test"],
+  "exclude": ["node_modules/**", "packages/*/node_modules/**", "**/*.d.ts"]
 }


### PR DESCRIPTION
This PR will hopefully demonstrate what I consider to be a better practice for adding any ORMs to loopback4.

This **should also mean that the legacy-juggler, and any possible future "juggler"/in-house ORMs** would follow a pattern similar to this, so that all ORMs receive the same treatment with respect to API compatibility.

connected to strongloop/loopback-next#537

Ideally, we'll be able to take this approach and enhance it, or learn from it to make an even better pattern for ORM wireup in loopback4.
